### PR TITLE
run on windows

### DIFF
--- a/daphne/libretro/libretro.cpp
+++ b/daphne/libretro/libretro.cpp
@@ -625,6 +625,7 @@ bool retro_load_game_get_path(const struct retro_game_info *in_game)
 
 	// Look for the last slash in the path.
 	const char * pstr_filename = strrchr(in_game->path, '/');
+		if (pstr_filename == NULL) pstr_filename = strrchr(in_game->path, '\\'); //windows
 	if (pstr_filename == NULL)
 	{
 		// We could have the case of just a filename.


### PR DESCRIPTION
ok ive managed to get this to run on windows files need to be copied to various places at the moment but it does run

![lair-180802-115040](https://user-images.githubusercontent.com/6128601/43580636-13af8ad4-964e-11e8-930a-fb079902263b.png)

input doesnt seem to be working either but its a start

a few notes the following needs added to the directory you run retroarch from
(your game sound files) 
sound/

https://github.com/grant2258/daphne-emu/tree/retropie/sound


now for the pics 

(only one file needs added here youll just drop out of ra if you dont place this file)
pics/ConsoleFont.bmp

https://github.com/libretro/daphne/blob/afc677b8c9257c3db8b3d6847038e24e51c1e3c9/daphne/daphne-1.0-src/daphne.cpp#L219

https://github.com/grant2258/hypseus/tree/master/pics

the rest can safely go in content dir/pics

now one last thing you need to do is copy your framefile to contents_dir/framefile

ill use dragons lair as an example
it originally reads 
151	lair.m2v

now you need to point it to your directory relative to framefile dir
151	../lair.daphne/lair.m2v


obviously youll need your roms in the contents/roms


enjoy hopefully thats enough info to get you guys up and running


