### PR TITLE
(libretro) Fix crash when loaded without content.

### DIFF
--- a/daphne/daphne-1.0-src/daphne.cpp
+++ b/daphne/daphne-1.0-src/daphne.cpp
@@ -292,18 +292,18 @@ int main_daphne_mainloop()
 
 int main_daphne_shutdown()
 {
-	g_game->pre_shutdown();
-
 	int result_code = 0;	// daphne will exit without any errors
-
-	g_ldp->pre_shutdown();
-	g_game->video_shutdown();
-
-	sound_shutdown();
-	shutdown_display();
 
 	if (g_game)
 	{
+		g_game->pre_shutdown();
+
+		g_ldp->pre_shutdown();
+		g_game->video_shutdown();
+
+		sound_shutdown();
+		shutdown_display();
+
 		delete(g_game);
 		g_game = NULL;
 	}
@@ -324,7 +324,6 @@ void set_serial_port(unsigned char i)
 {
 	serial_port = i;
 }
-
 
 unsigned char get_serial_port()
 {


### PR DESCRIPTION
NOTE: Please review and test this!

This fixes a crash when loading daphne without any content.
```
retroarch -L /path/to/daphne_libretro.so
```
The problem is that it will crash in `game::pre_shutdown()` from `daphne/daphne-1.0-src/game/game.cpp` when `m_nvram_size` is never set to `0`.

https://github.com/libretro/daphne/blob/4dd6fc8a70adb2266432c7ebb17ecab2dec867a1/daphne/daphne-1.0-src/game/game.cpp#L212

It will do this because when daphne exits it will attempt to save sram from unexpected exits, however `m_nvram_size` is only set if running a game. I think the easiest way to solve this is to check if a game was actually ran before trying to save sram and shutdown other things that were never started.

I could not figure out how to successfully load content and have not made sure this doesn't break loading content as a result. I suspect it will be fine, but if someone who can test this properly will make sure I would really appreciate it.