### PR TITLE
Force deca from local scope

### DIFF
--- a/daphne/daphne-1.0-src/cpu/mc6809.cpp
+++ b/daphne/daphne-1.0-src/cpu/mc6809.cpp
@@ -1715,7 +1715,7 @@ static void(*code[])(void) =
 ,cd10,cd11,nopm,synm,what,what,lbra,lbsr,what,daam,orcc,what,andc,sexm,exgm,tfrm
 ,bras,brns,bhis,blss,bccs,blos,bnes,beqs,bvcs,bvss,bpls,bmis,bges,blts,bgts,bles
 ,leax,leay,leas,leau,pshs,puls,pshu,pulu,what,rtsm,abxm,rtim,cwai,mulm,what,swim
-,nega,what,what,coma,lsra,what,rora,asra,asla,rola,deca,what,inca,tsta,what,clra
+,nega,what,what,coma,lsra,what,rora,asra,asla,rola,::deca,what,inca,tsta,what,clra
 ,negb,what,what,comb,lsrb,what,rorb,asrb,aslb,rolb,decb,what,incb,tstb,what,clrb
 ,negm,what,what,comm,lsrm,what,rorm,asrm,aslm,rolm,decm,what,incm,tstm,jmpm,clrm
 ,negm,what,what,comm,lsrm,what,rorm,asrm,aslm,rolm,decm,what,incm,tstm,jmpm,clrm


### PR DESCRIPTION
C++ 11 has a deca in the ratio class. The clang in NDK r22 somehow
has ratio in scope, causing an ambiguous reference.